### PR TITLE
Enhanced to support for multiple repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Issues are pulled based on `updated_at` field, meaning any update to an issue or
 
 The connector writes to topic that is great candidate to demonstrate *log compaction*. It's also a fun way to automate your GitHub workflow. 
 
-It's finally aimed to be an educative example to demonstrate how to write a Source Connector a little less trivial than the `FileStreamSourceConnector` provided in Kafka.
-
 # Configuration
 
 ```
@@ -21,6 +19,11 @@ auth.username=your_username
 auth.password=your_password
 ```
 Note: Configuration for github.repos should be set and should follow the pattern owner1/repo1:topic1,owner2/repo2:topic2 ....
+
+You can control the number of tasks to run by using *tasks.max*. This allows work to be divided from task i.e., each task will be assigned few repositories ans will 
+fetch issues for those repositories. 
+
+Set *since.timestamp* to fetch the issues of repositories which have been updated after the required timestamp.
 
 # Running in development
 

--- a/README.md
+++ b/README.md
@@ -10,20 +10,26 @@ The connector writes to topic that is great candidate to demonstrate *log compac
 
 ```
 name=GitHubSourceConnectorDemo
-tasks.max=1
+tasks.max=2
 connector.class=com.simplesteph.kafka.GitHubSourceConnector
-github.repos=kubernetes/kubernetes:github-issues-kubernetes,apache/kafka:github-issues-kafka
 since.timestamp=2017-01-01T00:00:00Z
-# I heavily recommend you set those two fields:
-auth.username=your_username
-auth.password=your_password
+#Pattern to be followed for mentioning repositories owner/repo:topic
+github.repos=kubernetes/kubernetes:github-issues-kubernetes,apache/kafka:github-issues-kafka
+# I heavily recommend you set auth.accesstoken field:
+#auth.username=
+#auth.password=
+auth.accesstoken=your_accestoken
 ```
-Note: Configuration for github.repos should be set and should follow the pattern owner1/repo1:topic1,owner2/repo2:topic2 ....
+Note: Configuration for **github.repos** should be set and should follow the pattern owner1/repo1:topic1,owner2/repo2:topic2 ....
 
-You can control the number of tasks to run by using *tasks.max*. This allows work to be divided among tasks i.e., each task will be assigned few repositories and 
+You can control the number of tasks to run by using **tasks.max**. This allows work to be divided among tasks i.e., each task will be assigned few repositories and 
 will fetch issues for those repositories. 
 
-Set *since.timestamp* to fetch the issues of repositories which have been updated after the required timestamp.
+Set **since.timestamp** to fetch the issues of repositories which have been updated after the required timestamp.
+
+Use either **auth.username** and **auth.password** or only **auth.accesstoken**. Using **auth.accesstoken** is preferable 
+because authentication with *username* and *password* has been deprecated and will soon be not supported by Github APIs.
+For generating the *personal accesstoken* follow the steps in [https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) 
 
 # Running in development
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ auth.password=your_password
 ```
 Note: Configuration for github.repos should be set and should follow the pattern owner1/repo1:topic1,owner2/repo2:topic2 ....
 
-You can control the number of tasks to run by using *tasks.max*. This allows work to be divided from task i.e., each task will be assigned few repositories ans will 
-fetch issues for those repositories. 
+You can control the number of tasks to run by using *tasks.max*. This allows work to be divided among tasks i.e., each task will be assigned few repositories and 
+will fetch issues for those repositories. 
 
 Set *since.timestamp* to fetch the issues of repositories which have been updated after the required timestamp.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ https://links.datacumulus.com/kafka-connect-coupon
 
 # Kafka Connect Source GitHub
 
-This connector allows you to get a stream of issues and pull requests from your GitHub repository, using the GitHub Api: https://developer.github.com/v3/issues/#list-issues-for-a-repository
+This connector allows you to get a stream of issues and pull requests from GitHub repositories, using the GitHub Api: https://developer.github.com/v3/issues/#list-issues-for-a-repository
 
 Issues are pulled based on `updated_at` field, meaning any update to an issue or pull request will appear in the stream. 
 
@@ -24,14 +24,13 @@ This connector is not perfect and can be improved, please feel free to submit an
 name=GitHubSourceConnectorDemo
 tasks.max=1
 connector.class=com.simplesteph.kafka.GitHubSourceConnector
-topic=github-issues
-github.owner=kubernetes
-github.repo=kubernetes
+github.repos=kubernetes/kubernetes:github-issues-kubernetes,apache/kafka:github-issues-kafka
 since.timestamp=2017-01-01T00:00:00Z
 # I heavily recommend you set those two fields:
 auth.username=your_username
 auth.password=your_password
 ```
+Note: Configuration for github.repos should be set and should follow the pattern owner1/repo1:topic1,owner2/repo2:topic2 ....
 
 # Running in development
 
@@ -49,4 +48,14 @@ The simplest way to run `run.sh` is to have docker installed. It will pull a Doc
 
 Note: Java 8 is required for this connector. 
 
-TODO
+#### Distributed Mode
+
+Build the project using `./build.sh`.
+
+Paste the folder `target/kafka-connnect-github-source-1.1-package /share/java/kafka-connect-github-source`(this folder has all jars of the project) 
+in connect-workers' `plugin.path`(can be found in the connect-workers' properties) 
+directory. The connect-worker should be able to detect `GitHubSourceConnector`.
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-# Learning
-
-This project is a companion repository to the [Apache Kafka Connect course on Udemy](https://links.datacumulus.com/kafka-connect-coupon). 
-
-https://links.datacumulus.com/kafka-connect-coupon
-
 # Kafka Connect Source GitHub
 
 This connector allows you to get a stream of issues and pull requests from GitHub repositories, using the GitHub Api: https://developer.github.com/v3/issues/#list-issues-for-a-repository
@@ -13,10 +7,6 @@ Issues are pulled based on `updated_at` field, meaning any update to an issue or
 The connector writes to topic that is great candidate to demonstrate *log compaction*. It's also a fun way to automate your GitHub workflow. 
 
 It's finally aimed to be an educative example to demonstrate how to write a Source Connector a little less trivial than the `FileStreamSourceConnector` provided in Kafka.
-
-# Contributing
-
-This connector is not perfect and can be improved, please feel free to submit any PR you deem useful. 
 
 # Configuration
 
@@ -56,6 +46,6 @@ Paste the folder `target/kafka-connnect-github-source-1.1-package /share/java/ka
 in connect-workers' `plugin.path`(can be found in the connect-workers' properties) 
 directory. The connect-worker should be able to detect `GitHubSourceConnector`.
 
+# Contributing
 
-
-
+This connector can be improved much, please feel free to submit any PR you deem useful.

--- a/config/GitHubSourceConnectorExample.properties
+++ b/config/GitHubSourceConnectorExample.properties
@@ -4,6 +4,7 @@ connector.class=com.simplesteph.kafka.GitHubSourceConnector
 since.timestamp=2017-01-01T00:00:00Z
 #Pattern to be followed for mentioning repositories owner/repo:topic
 github.repos=kubernetes/kubernetes:github-issues-kubernetes,apache/kafka:github-issues-kafka
-# I heavily recommend you set those two fields:
+# I heavily recommend you set auth.accesstoken field:
 #auth.username=
 #auth.password=
+auth.accesstoken=your_accestoken

--- a/config/GitHubSourceConnectorExample.properties
+++ b/config/GitHubSourceConnectorExample.properties
@@ -1,10 +1,9 @@
 name=GitHubSourceConnectorDemo
-tasks.max=1
+tasks.max=2
 connector.class=com.simplesteph.kafka.GitHubSourceConnector
-topic=github-issues
-github.owner=kubernetes
-github.repo=kubernetes
 since.timestamp=2017-01-01T00:00:00Z
+#Pattern to be followed for mentioning repositories owner/repo:topic
+github.repos=kubernetes/kubernetes:github-issues-kubernetes,apache/kafka:github-issues-kafka
 # I heavily recommend you set those two fields:
-# auth.username=your_username
-# auth.password=your_password
+#auth.username=
+#auth.password=

--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,16 @@
             <artifactId>slf4j-log4j12</artifactId>
             <version>1.7.25</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.mashape.unirest/unirest-java -->
         <dependency>
-            <groupId>com.mashape.unirest</groupId>
-            <artifactId>unirest-java</artifactId>
-            <version>1.4.9</version>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20190722</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.10</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/com/simplesteph/kafka/GitHubAPIHttpClient.java
+++ b/src/main/java/com/simplesteph/kafka/GitHubAPIHttpClient.java
@@ -1,25 +1,32 @@
 package com.simplesteph.kafka;
 
-import com.mashape.unirest.http.Headers;
-import com.mashape.unirest.http.HttpResponse;
-import com.mashape.unirest.http.JsonNode;
-import com.mashape.unirest.http.Unirest;
-import com.mashape.unirest.http.exceptions.UnirestException;
-import com.mashape.unirest.request.GetRequest;
+import com.simplesteph.kafka.utils.SetBasicAuthUtil;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.util.EntityUtils;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.HashMap;
 
 // GitHubHttpAPIClient used to launch HTTP Get requests
-public class GitHubAPIHttpClient {
+public class GitHubAPIHttpClient implements Closeable {
 
     private static final Logger log = LoggerFactory.getLogger(GitHubAPIHttpClient.class);
 
+    private HttpClientProvider httpClientProvider;
+    private HttpClient httpClient;
     // for efficient http requests
     private Integer XRateLimit = 9999;
     private Integer XRateRemaining = 9999;
@@ -29,27 +36,44 @@ public class GitHubAPIHttpClient {
 
     public GitHubAPIHttpClient(GitHubSourceConnectorConfig config){
         this.config = config;
+        this.httpClientProvider=new HttpClientProvider();
+        this.httpClient=this.httpClientProvider.getHttpClient();
     }
 
-    protected JSONArray getNextIssues(Integer page, Instant since) throws InterruptedException {
+    protected JSONArray getNextIssues(RepositoryVariables repoVar) throws InterruptedException {
 
-        HttpResponse<JsonNode> jsonResponse;
+        HttpResponse httpResponse;
         try {
-            jsonResponse = getNextIssuesAPI(page, since);
+            httpResponse = getNextIssuesAPI(repoVar);
+            //reading the headers of the response
+            HashMap<String,String> headers=new HashMap<String, String>();
+            for(Header h:httpResponse.getAllHeaders())
+                headers.put(h.getName(),h.getValue());
 
-            // deal with headers in any case
-            Headers headers = jsonResponse.getHeaders();
-            XRateLimit = Integer.valueOf(headers.getFirst("X-RateLimit-Limit"));
-            XRateRemaining = Integer.valueOf(headers.getFirst("X-RateLimit-Remaining"));
-            XRateReset = Integer.valueOf(headers.getFirst("X-RateLimit-Reset"));
-            switch (jsonResponse.getStatus()){
+            XRateLimit = Integer.valueOf(httpResponse.getFirstHeader("X-RateLimit-Limit").getValue());
+            XRateRemaining = Integer.valueOf(httpResponse.getFirstHeader("X-RateLimit-Remaining").getValue());
+            XRateReset = Integer.valueOf(httpResponse.getFirstHeader("X-RateLimit-Reset").getValue());
+            //reading the httpResponse content(body)
+            String jsonResponse= EntityUtils.toString(httpResponse.getEntity());
+            JSONArray jsonArray=new JSONArray();
+            JSONObject jsonBody=new JSONObject();
+            try{
+                //try to read httpResponse as JSONArray if possible
+                jsonArray=new JSONArray(jsonResponse);
+            }
+            catch (JSONException ex){
+                //read as JSONObject
+                jsonBody=new JSONObject(jsonResponse);
+            }
+
+            switch (httpResponse.getStatusLine().getStatusCode()){
                 case 200:
-                    return jsonResponse.getBody().getArray();
+                    return jsonArray;
                 case 401:
                     throw new ConnectException("Bad GitHub credentials provided, please edit your config");
                 case 403:
                     // we have issues too many requests.
-                    log.info(jsonResponse.getBody().getObject().getString("message"));
+                    log.info(jsonBody.getString("message"));
                     log.info(String.format("Your rate limit is %s", XRateLimit));
                     log.info(String.format("Your remaining calls is %s", XRateRemaining));
                     log.info(String.format("The limit will reset at %s",
@@ -57,41 +81,41 @@ public class GitHubAPIHttpClient {
                     long sleepTime = XRateReset - Instant.now().getEpochSecond();
                     log.info(String.format("Sleeping for %s seconds", sleepTime ));
                     Thread.sleep(1000 * sleepTime);
-                    return getNextIssues(page, since);
+                    return getNextIssues(repoVar);
                 default:
-                    log.error(constructUrl(page, since));
-                    log.error(String.valueOf(jsonResponse.getStatus()));
-                    log.error(jsonResponse.getBody().toString());
-                    log.error(jsonResponse.getHeaders().toString());
+                    log.error(constructUrl(repoVar));
+                    log.error(String.valueOf(httpResponse.getStatusLine().getStatusCode()));
+                    log.error(jsonResponse);
+                    log.error(headers.toString());
                     log.error("Unknown error: Sleeping 5 seconds " +
                             "before re-trying");
                     Thread.sleep(5000L);
-                    return getNextIssues(page, since);
+                    return getNextIssues(repoVar);
             }
-        } catch (UnirestException e) {
+        } catch (IOException e) {
             e.printStackTrace();
             Thread.sleep(5000L);
             return new JSONArray();
         }
     }
 
-    protected HttpResponse<JsonNode> getNextIssuesAPI(Integer page, Instant since) throws UnirestException {
-        GetRequest unirest = Unirest.get(constructUrl(page, since));
+    protected HttpResponse getNextIssuesAPI(RepositoryVariables repoVar) throws IOException {
+        HttpGet httpGet=new HttpGet(constructUrl(repoVar));
         if (!config.getAuthUsername().isEmpty() && !config.getAuthPassword().isEmpty() ){
-            unirest = unirest.basicAuth(config.getAuthUsername(), config.getAuthPassword());
+            SetBasicAuthUtil.SetBasicAuth(httpGet,config.getAuthUsername(), config.getAuthPassword());
         }
-        log.debug(String.format("GET %s", unirest.getUrl()));
-        return unirest.asJson();
+        HttpResponse response= httpClient.execute(httpGet);
+        return response;
     }
 
-    protected String constructUrl(Integer page, Instant since){
+    protected String constructUrl(RepositoryVariables repoVar){
         return String.format(
                 "https://api.github.com/repos/%s/%s/issues?page=%s&per_page=%s&since=%s&state=all&direction=asc&sort=updated",
-                config.getOwnerConfig(),
-                config.getRepoConfig(),
-                page,
+                repoVar.getOwner(),
+                repoVar.getRepoName(),
+                repoVar.nextPageToVisit,
                 config.getBatchSize(),
-                since.toString());
+                repoVar.nextQuerySince.toString());
     }
 
     public void sleep() throws InterruptedException {
@@ -107,5 +131,11 @@ public class GitHubAPIHttpClient {
             log.info(String.format("Approaching limit soon, you have %s requests left", XRateRemaining));
             sleep();
         }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if(httpClientProvider!=null)
+            httpClientProvider.close();
     }
 }

--- a/src/main/java/com/simplesteph/kafka/GitHubAPIHttpClient.java
+++ b/src/main/java/com/simplesteph/kafka/GitHubAPIHttpClient.java
@@ -1,6 +1,7 @@
 package com.simplesteph.kafka;
 
 import com.simplesteph.kafka.utils.SetBasicAuthUtil;
+import com.simplesteph.kafka.utils.SetBearerAuthUtil;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -101,7 +102,11 @@ public class GitHubAPIHttpClient implements Closeable {
 
     protected HttpResponse getNextIssuesAPI(RepositoryVariables repoVar) throws IOException {
         HttpGet httpGet=new HttpGet(constructUrl(repoVar));
-        if (!config.getAuthUsername().isEmpty() && !config.getAuthPassword().isEmpty() ){
+        if(!config.getAuthAccesstoken().isEmpty()){
+            SetBearerAuthUtil.SetBearerAuthUtil(httpGet,config.getAuthAccesstoken());
+        }
+
+        else if (!config.getAuthUsername().isEmpty() && !config.getAuthPassword().isEmpty() ){
             SetBasicAuthUtil.SetBasicAuth(httpGet,config.getAuthUsername(), config.getAuthPassword());
         }
         HttpResponse response= httpClient.execute(httpGet);

--- a/src/main/java/com/simplesteph/kafka/GitHubSourceConnectorConfig.java
+++ b/src/main/java/com/simplesteph/kafka/GitHubSourceConnectorConfig.java
@@ -34,6 +34,9 @@ public class GitHubSourceConnectorConfig extends AbstractConfig {
     private static final String AUTH_PASSWORD_DOC = "Optional Password to authenticate calls";
 
 
+    public static final String AUTH_ACCESSTOKEN_CONFIG = "auth.accesstoken";
+    private static final String AUTH_ACCESSTOKEN_DOC = "Optional accesstoken to authenticate calls";
+
     public GitHubSourceConnectorConfig(ConfigDef config, Map<String, String> parsedConfig) {
         super(config, parsedConfig);
     }
@@ -49,7 +52,8 @@ public class GitHubSourceConnectorConfig extends AbstractConfig {
                 .define(SINCE_CONFIG, Type.STRING, ZonedDateTime.now().minusYears(1).toInstant().toString(),
                         new TimestampValidator(), Importance.HIGH, SINCE_DOC)
                 .define(AUTH_USERNAME_CONFIG, Type.STRING, "", Importance.HIGH, AUTH_USERNAME_DOC)
-                .define(AUTH_PASSWORD_CONFIG, Type.PASSWORD, "", Importance.HIGH, AUTH_PASSWORD_DOC);
+                .define(AUTH_PASSWORD_CONFIG, Type.PASSWORD, "", Importance.HIGH, AUTH_PASSWORD_DOC)
+                .define(AUTH_ACCESSTOKEN_CONFIG, Type.PASSWORD, "", Importance.HIGH, AUTH_ACCESSTOKEN_DOC);
     }
 
     public String[] getReposConfig(){return this.getString(REPOS_CONFIG).split(",");}
@@ -69,4 +73,6 @@ public class GitHubSourceConnectorConfig extends AbstractConfig {
     public String getAuthPassword(){
         return this.getPassword(AUTH_PASSWORD_CONFIG).value();
     }
+
+    public String getAuthAccesstoken(){return this.getPassword(AUTH_ACCESSTOKEN_CONFIG).value();}
 }

--- a/src/main/java/com/simplesteph/kafka/GitHubSourceConnectorConfig.java
+++ b/src/main/java/com/simplesteph/kafka/GitHubSourceConnectorConfig.java
@@ -1,6 +1,7 @@
 package com.simplesteph.kafka;
 
 import com.simplesteph.kafka.Validators.BatchSizeValidator;
+import com.simplesteph.kafka.Validators.ReposPatternValidator;
 import com.simplesteph.kafka.Validators.TimestampValidator;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
@@ -14,20 +15,14 @@ import java.util.Map;
 
 public class GitHubSourceConnectorConfig extends AbstractConfig {
 
-    public static final String TOPIC_CONFIG = "topic";
-    private static final String TOPIC_DOC = "Topic to write to";
-
-    public static final String OWNER_CONFIG = "github.owner";
-    private static final String OWNER_DOC = "Owner of the repository you'd like to follow";
-
-    public static final String REPO_CONFIG = "github.repo";
-    private static final String REPO_DOC = "Repository you'd like to follow";
-
     public static final String SINCE_CONFIG = "since.timestamp";
     private static final String SINCE_DOC =
             "Only issues updated at or after this time are returned.\n"
                     + "This is a timestamp in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ.\n"
                     + "Defaults to a year from first launch.";
+
+    public static final String REPOS_CONFIG="github.repos";
+    public static final String REPOS_DOC="Repositories you'd like to follow . owner/repo:topic pattern to be followed for mentioning repositories.";
 
     public static final String BATCH_SIZE_CONFIG = "batch.size";
     private static final String BATCH_SIZE_DOC = "Number of data points to retrieve at a time. Defaults to 100 (max value)";
@@ -49,9 +44,7 @@ public class GitHubSourceConnectorConfig extends AbstractConfig {
 
     public static ConfigDef conf() {
         return new ConfigDef()
-                .define(TOPIC_CONFIG, Type.STRING, Importance.HIGH, TOPIC_DOC)
-                .define(OWNER_CONFIG, Type.STRING, Importance.HIGH, OWNER_DOC)
-                .define(REPO_CONFIG, Type.STRING, Importance.HIGH, REPO_DOC)
+                .define(REPOS_CONFIG,Type.STRING,"apache/kafka:github-issues",new ReposPatternValidator(),Importance.HIGH,REPOS_DOC)
                 .define(BATCH_SIZE_CONFIG, Type.INT, 100, new BatchSizeValidator(), Importance.LOW, BATCH_SIZE_DOC)
                 .define(SINCE_CONFIG, Type.STRING, ZonedDateTime.now().minusYears(1).toInstant().toString(),
                         new TimestampValidator(), Importance.HIGH, SINCE_DOC)
@@ -59,13 +52,7 @@ public class GitHubSourceConnectorConfig extends AbstractConfig {
                 .define(AUTH_PASSWORD_CONFIG, Type.PASSWORD, "", Importance.HIGH, AUTH_PASSWORD_DOC);
     }
 
-    public String getOwnerConfig() {
-        return this.getString(OWNER_CONFIG);
-    }
-
-    public String getRepoConfig() {
-        return this.getString(REPO_CONFIG);
-    }
+    public String[] getReposConfig(){return this.getString(REPOS_CONFIG).split(",");}
 
     public Integer getBatchSize() {
         return this.getInt(BATCH_SIZE_CONFIG);
@@ -73,10 +60,6 @@ public class GitHubSourceConnectorConfig extends AbstractConfig {
 
     public Instant getSince() {
         return Instant.parse(this.getString(SINCE_CONFIG));
-    }
-
-    public String getTopic() {
-        return this.getString(TOPIC_CONFIG);
     }
 
     public String getAuthUsername() {

--- a/src/main/java/com/simplesteph/kafka/HttpClientProvider.java
+++ b/src/main/java/com/simplesteph/kafka/HttpClientProvider.java
@@ -1,0 +1,66 @@
+package com.simplesteph.kafka;
+
+import org.apache.http.config.Registry;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.TrustStrategy;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.ssl.SSLContexts;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLContext;
+import java.io.Closeable;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
+public class HttpClientProvider implements Closeable {
+    private static final Logger log = LoggerFactory.getLogger(HttpClientProvider.class);
+    private PoolingHttpClientConnectionManager poolingConnectionManager;
+    private CloseableHttpClient httpClient;
+    public HttpClientProvider(){
+        CreateAllSSLHttpClient();
+    }
+    public void CreateAllSSLHttpClient() {
+        try {
+            TrustStrategy acceptingTrustStrategy = (cert, authType) -> true;
+            SSLContext sslContext = SSLContexts.custom().loadTrustMaterial(null, acceptingTrustStrategy).build();
+            SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(sslContext,
+                    NoopHostnameVerifier.INSTANCE);
+
+            Registry<ConnectionSocketFactory> socketFactoryRegistry =
+                    RegistryBuilder.<ConnectionSocketFactory>create()
+                            .register("https", sslsf)
+                            .register("http", new PlainConnectionSocketFactory())
+                            .build();
+
+            this.poolingConnectionManager  =
+                    new PoolingHttpClientConnectionManager(socketFactoryRegistry);
+            this.httpClient = HttpClients.custom().setSSLSocketFactory(sslsf)
+                    .setConnectionManager(poolingConnectionManager).build();
+
+            log.info("Successfully created AcceptAllSSLHttpClient");
+        }
+        catch (GeneralSecurityException ex){
+            log.error("Unable to create AcceptAllSSLHttpClient");
+        }
+    }
+    public CloseableHttpClient getHttpClient(){
+        return httpClient;
+    }
+    @Override
+    public void close() throws IOException {
+        if(httpClient!=null)
+            httpClient.close();
+        if(poolingConnectionManager!=null) {
+            poolingConnectionManager.close();
+            poolingConnectionManager.shutdown();
+        }
+    }
+}

--- a/src/main/java/com/simplesteph/kafka/RepositoryVariables.java
+++ b/src/main/java/com/simplesteph/kafka/RepositoryVariables.java
@@ -1,0 +1,32 @@
+package com.simplesteph.kafka;
+import java.time.Instant;
+
+//This is a class which has all necessary details about a repository
+public class RepositoryVariables {
+    private String repository;
+    private String owner;
+    private String repo_name;
+    private String topic;
+    protected Instant nextQuerySince;
+    protected Integer lastIssueNumber;
+    protected Integer nextPageToVisit = 1;
+    protected Instant lastUpdatedAt;
+    public RepositoryVariables(String repository){
+        this.repository=repository;
+        String components[]=repository.split("[/:]");         //splitting repository string which is of pattern "owner/repo:topic"
+        this.owner=components[0];
+        this.repo_name=components[1];
+        this.topic=components[2];
+    }
+
+    public String getOwner(){
+        return owner;
+    }
+    public String getRepoName(){
+        return repo_name;
+    }
+
+    public String getTopic(){
+        return topic;
+    }
+}

--- a/src/main/java/com/simplesteph/kafka/Validators/ReposPatternValidator.java
+++ b/src/main/java/com/simplesteph/kafka/Validators/ReposPatternValidator.java
@@ -1,0 +1,18 @@
+package com.simplesteph.kafka.Validators;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
+
+public class ReposPatternValidator implements ConfigDef.Validator {
+    @Override
+    public void ensureValid(String name, Object value) {
+
+        String []repos=((String) value).split(",");
+
+        for(String repo:repos){
+            //[A-Za-z0-9_.-] are the characters that are allowed for naming in github and [a-zA-Z0-9\._-] in kafka topics
+            if(!repo.matches("[A-Za-z0-9_.-]{1,}/[A-Za-z0-9_.-]{1,}:[a-zA-Z0-9\\._-]{1,}"))
+                throw new ConfigException(name,value,"'owner1/repo1:topic1,owner2/repo2:topic2' pattern to be followed for mentioning repositories");
+        }
+    }
+}

--- a/src/main/java/com/simplesteph/kafka/utils/RepoJoinUtil.java
+++ b/src/main/java/com/simplesteph/kafka/utils/RepoJoinUtil.java
@@ -1,0 +1,15 @@
+package com.simplesteph.kafka.utils;
+
+public class RepoJoinUtil {
+    public static String Join(String s1,String s2){
+        if(s1==null&&s2==null)
+            return "";
+        if(s1==null||s1.trim().isEmpty())
+            return s2.trim();
+        else if(s2==null||s2.trim().isEmpty())
+            return s1.trim();
+        else
+            return s1.trim()+","+s2.trim();
+    }
+
+}

--- a/src/main/java/com/simplesteph/kafka/utils/SetBasicAuthUtil.java
+++ b/src/main/java/com/simplesteph/kafka/utils/SetBasicAuthUtil.java
@@ -1,0 +1,19 @@
+package com.simplesteph.kafka.utils;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpRequest;
+
+import java.nio.charset.StandardCharsets;
+
+public class SetBasicAuthUtil {
+    public static HttpRequest SetBasicAuth(HttpRequest request,String username,String password ){
+        String auth = username + ":" + password;
+        byte[] encodedAuth = Base64.encodeBase64(
+                auth.getBytes(StandardCharsets.ISO_8859_1));
+        String authHeader = "Basic " + new String(encodedAuth);
+        request.setHeader(HttpHeaders.AUTHORIZATION, authHeader);
+        return request;
+    }
+
+}

--- a/src/main/java/com/simplesteph/kafka/utils/SetBearerAuthUtil.java
+++ b/src/main/java/com/simplesteph/kafka/utils/SetBearerAuthUtil.java
@@ -1,0 +1,12 @@
+package com.simplesteph.kafka.utils;
+
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpRequest;
+
+public class SetBearerAuthUtil {
+    public static HttpRequest SetBearerAuthUtil(HttpRequest request, String bearToken){
+        String authHeader = "Bearer" + " " + bearToken;
+        request.setHeader(HttpHeaders.AUTHORIZATION, authHeader);
+        return request;
+    }
+}

--- a/src/test/java/com/simplesteph/kafka/GitHubSourceConnectorConfigTest.java
+++ b/src/test/java/com/simplesteph/kafka/GitHubSourceConnectorConfigTest.java
@@ -18,11 +18,9 @@ public class GitHubSourceConnectorConfigTest {
     @Before
     public void setUpInitialConfig() {
         config = new HashMap<>();
-        config.put(OWNER_CONFIG, "foo");
-        config.put(REPO_CONFIG, "bar");
+        config.put(REPOS_CONFIG,"kubernetes/kubernetes:github-issues.31,foo-foo/bar_bar:github.issues");
         config.put(SINCE_CONFIG, "2017-04-26T01:23:45Z");
         config.put(BATCH_SIZE_CONFIG, "100");
-        config.put(TOPIC_CONFIG, "github-issues");
     }
 
     @Test
@@ -42,6 +40,17 @@ public class GitHubSourceConnectorConfigTest {
         GitHubSourceConnectorConfig config = new GitHubSourceConnectorConfig(this.config);
         config.getAuthPassword();
 
+    }
+
+    @Test
+    public void validateRepos() {
+        config.put(REPOS_CONFIG, "not-a-valid-pattern");
+        ConfigValue configValue = configDef.validateAll(config).get(REPOS_CONFIG);
+        assertTrue(configValue.errorMessages().size() > 0);
+
+        config.put(REPOS_CONFIG, "valid/pattern:followed");
+        configValue = configDef.validateAll(config).get(REPOS_CONFIG);
+        assertEquals(configValue.errorMessages().size() , 0);
     }
 
     @Test

--- a/src/test/java/com/simplesteph/kafka/GitHubSourceConnectorTest.java
+++ b/src/test/java/com/simplesteph/kafka/GitHubSourceConnectorTest.java
@@ -12,11 +12,9 @@ public class GitHubSourceConnectorTest {
 
   private Map<String, String> initialConfig() {
     Map<String, String> baseProps = new HashMap<>();
-    baseProps.put(OWNER_CONFIG, "foo");
-    baseProps.put(REPO_CONFIG, "bar");
+    baseProps.put(REPOS_CONFIG,"kubernetes/kubernetes:github-issues.31,foo-foo/bar_bar:github.issues,foo-bar/bar_foo:github.issues");
     baseProps.put(SINCE_CONFIG, "2017-04-26T01:23:45Z");
     baseProps.put(BATCH_SIZE_CONFIG, "100");
-    baseProps.put(TOPIC_CONFIG, "github-issues");
     return (baseProps);
   }
 
@@ -25,6 +23,9 @@ public class GitHubSourceConnectorTest {
       GitHubSourceConnector gitHubSourceConnector = new GitHubSourceConnector();
       gitHubSourceConnector.start(initialConfig());
       assertEquals(gitHubSourceConnector.taskConfigs(1).size(),1);
-      assertEquals(gitHubSourceConnector.taskConfigs(10).size(),1);
+      assertEquals(gitHubSourceConnector.taskConfigs(2).size(),2);
+      assertEquals(gitHubSourceConnector.taskConfigs(3).size(),3);
+      assertEquals(gitHubSourceConnector.taskConfigs(4).size(),3);
+      assertEquals(gitHubSourceConnector.taskConfigs(10).size(),3);
   }
 }


### PR DESCRIPTION
Changed to support for multiple repositories and topic (issue [#2](https://github.com/simplesteph/kafka-connect-github-source/issues/2)).

HttpClient is used for http calls. Did not create static HttpClient because HttpClient should be closed for freeing resources when no longer required , but HttpClient cannot be closed if static as there might be other task using it. So I used single HttpClient per task and is closed when task is stopped.