### PR TITLE
Kafka version bump and repositories section removed (not working anym…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <name>kafka-connect-github-source</name>
 
     <properties>
-        <kafka.version>0.10.2.0-cp1</kafka.version>
+        <kafka.version>3.3.2</kafka.version>
         <junit.version>4.12</junit.version>
     </properties>
 
@@ -92,10 +92,4 @@
             </resource>
         </resources>
     </build>
-    <repositories>
-        <repository>
-            <id>confluent</id>
-            <url>http://packages.confluent.io/maven/</url>
-        </repository>
-    </repositories>
 </project>


### PR DESCRIPTION
1. Repository `http://packages.confluent.io/maven/` is not working anymore with this setup.
2. Kafka version updated to last one (at the current time is 3.3.2). `0.10.2.0-cp1` is very old and not found on maven central.