### PR TITLE
Update rate limit header names and add TypeToken when deserializing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,11 @@
             <artifactId>unirest-java</artifactId>
             <version>1.4.9</version>
         </dependency>
-
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/simplesteph/kafka/GitHubAPIHttpClient.java
+++ b/src/main/java/com/simplesteph/kafka/GitHubAPIHttpClient.java
@@ -27,9 +27,9 @@ public class GitHubAPIHttpClient {
 
     GitHubSourceConnectorConfig config;
 
-    public static final String X_RATELIMIT_LIMIT_HEADER="X-Ratelimit-Limit";
-    public static final String X_RATELIMIT_REMAINING_HEADER="X-Ratelimit-Remaining";
-    public static final String X_RATELIMIT_RESET_HEADER="X-Ratelimit-Reset";
+    public static final String X_RATELIMIT_LIMIT_HEADER="X-RateLimit-Limit";
+    public static final String X_RATELIMIT_REMAINING_HEADER="X-RateLimit-Remaining";
+    public static final String X_RATELIMIT_RESET_HEADER="X-RateLimit-Reset";
 
     public GitHubAPIHttpClient(GitHubSourceConnectorConfig config){
         this.config = config;


### PR DESCRIPTION
I tested this on an Ubuntu system and it seems to be working. 
- Updated rate limit header names which was causing the connector to fail.
- Updated the GitHub source task to use TypeToken when deserializing JSON. This is meant to address an error during startup: https://github.com/simplesteph/kafka-connect-github-source/issues/5